### PR TITLE
Correct error handling in pipeline

### DIFF
--- a/build_scripts/codefresh.yml
+++ b/build_scripts/codefresh.yml
@@ -87,6 +87,7 @@ steps:
 
     run_all_tests:
         type: parallel
+        fail_fast: false
         steps:
             run_pylint:
                 title: Run pylint
@@ -170,5 +171,5 @@ steps:
                         steps.run_pylint.result == "failure" ||
                         steps.run_flake8.result == "failure" ||
                         steps.run_shellcheck.result == "failure" ||
-                        steps.run_unit_tests == "failure" ||
-                        steps.run_all_tests == "failure"
+                        steps.run_unit_tests.result == "failure" ||
+                        steps.run_all_tests.result == "failure"


### PR DESCRIPTION
There are two bugs in the current pipeline, which i tested by running a pared-down example pipeline:
1. The syntax in Check For Failed Tests is incorrect and that task will never run. All the checks need the .result at the end
2. The run_all_tests step will fail if any of it’s child steps fail, which means the clean_up step doesn’t run in the event of any static test failure.