### PR TITLE
Allow start_request() calls to pass request-specific information to structured logging

### DIFF
--- a/leaf_server_common/logging/logging_setup.py
+++ b/leaf_server_common/logging/logging_setup.py
@@ -23,7 +23,7 @@ from leaf_server_common.logging.structured_log_record \
 
 
 def setup_extra_logging_fields(metadata_dict: Dict[str, Any] = None,
-                               extra_logging_fields=None):
+                               extra_logging_fields: Dict[str, str] = None):
     """
     Sets up extra thread-specific fields to be logged with each
     log message.

--- a/leaf_server_common/server/request_logger.py
+++ b/leaf_server_common/server/request_logger.py
@@ -10,13 +10,17 @@
 #
 # END COPYRIGHT
 
+from typing import Dict
+
+
 class RequestLogger():
     """
     An interface defining an API for services to call for logging
     the beginning and end of servicing their requests.
     """
 
-    def start_request(self, caller, requestor_id, context):
+    def start_request(self, caller, requestor_id, context,
+                      service_logging_dict: Dict[str, str] = None):
         """
         Called by services to mark the beginning of a request
         inside their request methods.
@@ -25,6 +29,12 @@ class RequestLogger():
         :param requestor_id: A String representing other information about
                 the requestor which will be logged in a uniform fashion.
         :param context: a grpc.ServicerContext
+                from which structured logging fields can be derived from
+                request metadata
+        :param service_logging_dict: An optional service-specific dictionary
+                from which structured logging fields can be derived from
+                request-specific fields. When included, similarly named keys here
+                will be overriden by those from the context above.
         :return: The RequestLoggerAdapter to be used throughout the
                 processing of the request
         """

--- a/leaf_server_common/server/server_lifetime.py
+++ b/leaf_server_common/server/server_lifetime.py
@@ -9,6 +9,9 @@
 # leaf-server-common SDK Software in commercial settings.
 #
 # END COPYRIGHT
+
+from typing import Dict
+
 import random
 import time
 
@@ -181,7 +184,8 @@ class ServerLifetime(RequestLogger):
         # Finally stop the service
         self.server.stop(None)
 
-    def start_request(self, caller, requestor_id, context):
+    def start_request(self, caller, requestor_id, context,
+                      service_logging_dict: Dict[str, str] = None):
         """
         Called by client services to mark the beginning of a request
         inside their request methods.
@@ -190,6 +194,12 @@ class ServerLifetime(RequestLogger):
         :param requestor_id: A String representing other information about
                 the requestor which will be logged in a uniform fashion.
         :param context: a grpc.ServicerContext
+                from which structured logging fields can be derived from
+                request metadata
+        :param service_logging_dict: An optional service-specific dictionary
+                from which structured logging fields can be derived from
+                request-specific fields. When included, similarly named keys here
+                will be overriden by those from the context above.
         :return: The RequestLoggerAdapter for the request
         """
 
@@ -198,7 +208,7 @@ class ServerLifetime(RequestLogger):
         if context is not None:
             metadata = context.invocation_metadata()
             metadata_dict = GrpcMetadataUtil.to_dict(metadata)
-        setup_extra_logging_fields(metadata_dict)
+        setup_extra_logging_fields(metadata_dict, service_logging_dict)
         request_log = RequestLoggerAdapter(self.logger, None)
 
         # Log that the request was received by the caller

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 
-LIBRARY_VERSION = "0.1.3"
+LIBRARY_VERSION = "0.1.4"
 LEAF_COMMON_VERSION = "1.2.1"
 
 CURRENT_PYTHON = sys.version_info[:2]


### PR DESCRIPTION
When debugging pmdserver I found that user_id information was not getting into the logs.
This was because:
1. With the UI and gateway we are neither populating nor forwarding HTTP request metadata
2. There was no mechanism in the RequestLogger interface to get request-specific information into the structured logging.

This will help solve (2)