### PR TITLE
UN-2494 Improvements to AsyncToSyncGenerator

### DIFF
--- a/leaf_server_common/asyncio/async_to_sync_generator.py
+++ b/leaf_server_common/asyncio/async_to_sync_generator.py
@@ -83,6 +83,8 @@ class AsyncToSyncGenerator:
         # Wait for the result of the function. It should be an AsyncIterator
         async_iter: AsyncIterator = self.wait_for_future(future, AsyncIterator)
 
+        # "yield from" below basically says "I know this method returns a generator,
+        #  but just yield on up all of its results."
         yield from self.synchronously_iterate(async_iter)
 
     def synchronously_iterate(self, async_iter: AsyncIterator) -> Generator[Any, None, None]:


### PR DESCRIPTION
In debugging why the neuro-san client's direct connection was not working, I found that the AsyncToSyncGenerator needed some improvements.

* Add a synchronously_iterate() method which takes an AsyncIterator as a basis.
* Add a my_anext() method which wraps the Python anext() async iteration built-in into a regular function so it can be recognized as a co-routine for the AsyncioExecutor more easily.  This was the heart of the direct problem and acting on this makes the code significantly less squirrelly.
* Have synchronously_generate() method use the synchronously_iterate() method, as it operates on AsyncIterators anyway.

These changes have been tested in tandem with changes going into neuro-san