### PR TITLE
Pin opentelemetry version to get clean neuro-san installation.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ grpcio-tools>=1.62.0
 protobuf>=4.25.3
 
 # Open-telemetry logging
-opentelemetry-api>=1.23.0
-opentelemetry-sdk>=1.23.0
-opentelemetry-exporter-otlp>=1.23.0
+opentelemetry-api==1.23.0
+opentelemetry-sdk==1.23.0
+opentelemetry-exporter-otlp==1.23.0
 


### PR DESCRIPTION
PR title says it all.
Hopefully this is a temporary measure.
With this version pinning, we get clean and functioning neuro-san installation
for both Python 3.10 and 3.12

