### PR TITLE
Cap version by 1.27.0 - so not to pull in protobuf > 5.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ grpcio-reflection>=1.62.0
 grpcio-tools>=1.62.0
 
 # Pinning to older version of protobuf required for tensorflow==2.14.1
-protobuf>=4.25.3
+protobuf>=4.25.3,<5.0
 
 # Open-telemetry logging
 opentelemetry-api>=1.23.0,<=1.27.0


### PR DESCRIPTION
This PR title says it all.
